### PR TITLE
Move mPDF CSS overrides into Pressbooks mPDF plugin

### DIFF
--- a/hooks-admin.php
+++ b/hooks-admin.php
@@ -40,3 +40,33 @@ function pb_mpdf_add_theme_options_tab( $tabs ) {
 	return $tabs;
 }
 add_filter( 'pb_theme_options_tabs', 'pb_mpdf_add_theme_options_tab' );
+
+/**
+ * MPDF overrides.
+ *
+ * @param string $scss
+ * @return string $scss
+ */
+function pressbooks_theme_mpdf_css_override( $scss ) {
+	$options = get_option( 'pressbooks_theme_options_mpdf' );
+	$global_options = get_option( 'pressbooks_theme_options_global' );
+
+	// indent paragraphs
+	if ( $options['mpdf_indent_paragraphs'] ) {
+		$scss .= "p + p, .indent {text-indent: 2.0 em; }" . "\n";
+	}
+	// hyphenation
+	if ( $options['mpdf_hyphens'] ) {
+		$scss .= "p {hyphens: auto;}" . "\n";
+	}
+	// font-size
+	if ( $options['mpdf_fontsize'] ){
+                $scss .= 'body {font-size: 1.3em; line-height: 1.3; }' . "\n";
+        }
+	// chapter numbers
+	if ( ! $global_options['chapter_numbers'] ) {
+		$scss .= "h3.chapter-number {display: none;}" . "\n";
+	}
+	return $scss;
+}
+add_filter( 'pb_mpdf_css_override', 'pressbooks_theme_mpdf_css_override' );


### PR DESCRIPTION
See https://github.com/pressbooks/pressbooks/pull/701 and https://github.com/pressbooks/pressbooks/issues/452.