### PR TITLE
Fix #20

### DIFF
--- a/includes/modules/export/mpdf/class-pb-mpdf.php
+++ b/includes/modules/export/mpdf/class-pb-mpdf.php
@@ -39,10 +39,6 @@ if ( file_exists( PB_PLUGIN_DIR . 'symbionts/htmLawed/htmLawed.php' ) ) {
 	require_once( PB_PLUGIN_DIR . 'symbionts/htmLawed/htmLawed.php' );
 }
 
-if ( file_exists( PB_PLUGIN_DIR . 'vendor/vanilla/htmlawed/src/Htmlawed.php' ) ) {
-	require_once( PB_PLUGIN_DIR . 'vendor/vanilla/htmlawed/src/Htmlawed.php' );
-}
-
 class Pdf extends Export {
 
 	/**
@@ -538,6 +534,10 @@ class Pdf extends Export {
 		    'hook' => '\Pressbooks\Sanitize\html5_to_xhtml11',
 		    'tidy' => -1,
 		);
+
+		if ( function_exists( 'htmLawed' ) ) {
+			return htmLawed( $filtered, $config );
+		}
 
 		return \Htmlawed::filter( $filtered, $config );
 	}

--- a/includes/modules/export/mpdf/class-pb-mpdf.php
+++ b/includes/modules/export/mpdf/class-pb-mpdf.php
@@ -35,10 +35,6 @@ namespace Pressbooks\Modules\Export\Mpdf;
 
 use \Pressbooks\Modules\Export\Export;
 
-if ( file_exists( PB_PLUGIN_DIR . 'symbionts/htmLawed/htmLawed.php' ) ) {
-	require_once( PB_PLUGIN_DIR . 'symbionts/htmLawed/htmLawed.php' );
-}
-
 class Pdf extends Export {
 
 	/**
@@ -534,10 +530,6 @@ class Pdf extends Export {
 		    'hook' => '\Pressbooks\Sanitize\html5_to_xhtml11',
 		    'tidy' => -1,
 		);
-
-		if ( function_exists( 'htmLawed' ) ) {
-			return htmLawed( $filtered, $config );
-		}
 
 		return \Htmlawed::filter( $filtered, $config );
 	}


### PR DESCRIPTION
This should clear up the issue identified by @crism in #20. Two things that I am pretty sure should be true:

1. There is no need to require any files if `vanilla/htmlawed` is being used, as in that case it will have been autoloaded with Pressbooks Core.
2. We should be able to handle backwards compatibility with `function_exists()`. But this may not even be necessary, as I don't think this version of Pressbooks mPDF will work with Pressbooks < 3.9.8.