### PR TITLE
Fix htmLawed (again) for forthcoming Pressbooks 3.9.8.2

### DIFF
--- a/includes/modules/export/mpdf/class-pb-mpdf.php
+++ b/includes/modules/export/mpdf/class-pb-mpdf.php
@@ -531,7 +531,7 @@ class Pdf extends Export {
 		    'tidy' => -1,
 		);
 
-		return \Htmlawed::filter( $filtered, $config );
+		return \Pressbooks\HtmLawed::filter( $filtered, $config );
 	}
 
 	/**


### PR DESCRIPTION
Sorry, @bdolor—turns out that https://github.com/vanilla/htmlawed has a major regression so I'm using  an internal version… again. In future if I switch to a Composer install I'll continue to use `\Pressbooks\HtmLawed::filter()` as an alias so you won't need to mess with this anymore.